### PR TITLE
Add enhanced log monitor display options with toggle between full and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ QCMD is a powerful command-line tool that generates shell commands from natural 
 - Interactive shell with command history and autocompletion
 - Auto-correction mode that fixes commands automatically
 - Log analysis and monitoring with AI assistance
+- Session-based log monitoring with background monitoring support
 - System status monitoring and configuration management
 - Safe command execution with dangerous command detection
 - Highly customizable UI with color themes and display options
@@ -83,6 +84,19 @@ qcmd --shell
 
 ```bash
 qcmd --logs
+```
+
+### Log Monitoring
+
+```bash
+# List active log monitors
+qcmd --list-monitors
+
+# Start monitoring a specific log file
+qcmd --logs --log-file /var/log/syslog
+
+# Stop a log monitor
+qcmd --stop-monitor <session-id>
 ```
 
 ### System Status

--- a/bin/log-monitor
+++ b/bin/log-monitor
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Convenient shortcut script for opening the log monitor viewer
+
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Get the root directory of the project
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Run the view_monitor.py script
+python3 -m qcmd.qcmd_cli.log_analysis.cli.view_monitor "$@" 

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,75 @@
+# QCMD Log Monitoring Demos
+
+This directory contains demo scripts that showcase the log monitoring features in QCMD.
+
+## Log Monitor Demo
+
+The `log_monitor_demo.py` script demonstrates the following features:
+
+1. **Analyze Once**: Analyze a log file without continuous monitoring
+2. **Monitor with Analysis**: Monitor a log file with real-time AI analysis
+3. **Watch Only**: Monitor a log file without analysis (just watching for changes)
+4. **List Monitors**: Display all active log monitors
+5. **View Monitor**: Connect to a running monitor to see its output
+6. **Stop Monitor**: Stop a running monitor
+
+## Running the Demo
+
+1. Make sure you have QCMD installed:
+   ```
+   pip install -e /path/to/qcmd
+   ```
+
+2. Run the demo script:
+   ```
+   python log_monitor_demo.py
+   ```
+
+## Command Line Usage
+
+You can also use these features directly from the command line:
+
+### Analyze a log file once
+```
+qcmd --logs --log-file /var/log/syslog --analyze-once
+```
+
+### Monitor a log file with analysis
+```
+qcmd --logs --log-file /var/log/syslog --monitor-analyze
+```
+
+### Monitor a log file without analysis (just watch)
+```
+qcmd --logs --log-file /var/log/syslog --monitor-watch
+```
+
+### List active monitors
+```
+qcmd --list-monitors
+```
+
+### View a monitor
+```
+qcmd --view-monitor SESSION_ID
+```
+
+### Stop a monitor
+```
+qcmd --stop-monitor SESSION_ID
+```
+
+## Creating a Test Log File
+
+If you want to create a test log file for monitoring:
+
+```bash
+# Create an initial log file
+echo "[$(date)] Starting application..." > test.log
+
+# Add new log entries periodically in another terminal
+echo "[$(date)] New log entry - INFO: Normal operation" >> test.log
+echo "[$(date)] New log entry - ERROR: Connection failed" >> test.log
+```
+
+This lets you test the monitoring features with real log updates. 

--- a/demos/log_monitor_demo.py
+++ b/demos/log_monitor_demo.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+Demo script for QCMD log monitoring functionality.
+
+This script demonstrates the various ways to use the log monitoring features:
+1. Analyze a log file once
+2. Monitor a log file with analysis
+3. Monitor a log file without analysis (just watch)
+4. List active monitors
+5. View a monitor
+6. Stop a monitor
+"""
+
+import os
+import time
+import subprocess
+import signal
+import sys
+import tempfile
+import threading
+
+# Add project root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Import needed modules
+from qcmd_cli.log_analysis.log_files import (
+    analyze_log_file, handle_log_analysis, handle_log_selection,
+    list_active_log_monitors, stop_log_monitor, view_monitor
+)
+from qcmd_cli.log_analysis.monitor import monitor_log
+from qcmd_cli.ui.display import Colors
+
+
+def generate_log_entries(log_file, count=5, interval=2):
+    """Generate log entries to a file at specified intervals."""
+    print(f"\n{Colors.GREEN}Starting log generator thread...{Colors.END}")
+    for i in range(count):
+        log_entry = f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] Demo log entry #{i+1}"
+        if i % 3 == 0:
+            log_entry += " - ERROR: This is a sample error message"
+        
+        with open(log_file, 'a') as f:
+            f.write(log_entry + "\n")
+        
+        print(f"{Colors.BLUE}Added log entry #{i+1} to {log_file}{Colors.END}")
+        time.sleep(interval)
+    
+    print(f"{Colors.GREEN}Log generator thread finished.{Colors.END}")
+
+
+def demo_analyze_once():
+    """Demo analyzing a log file once."""
+    print(f"\n{Colors.CYAN}{Colors.BOLD}DEMO 1: Analyze Log File Once{Colors.END}")
+    
+    # Create a temporary log file
+    fd, temp_log = tempfile.mkstemp(suffix='.log')
+    os.close(fd)
+    
+    # Write some content to the log
+    with open(temp_log, 'w') as f:
+        f.write("[2025-04-13 10:00:00] Starting application...\n")
+        f.write("[2025-04-13 10:00:01] Initializing modules...\n")
+        f.write("[2025-04-13 10:00:02] ERROR: Failed to load config.json\n")
+        f.write("[2025-04-13 10:00:03] Using default configuration\n")
+        f.write("[2025-04-13 10:00:04] Application started successfully\n")
+    
+    print(f"{Colors.GREEN}Created test log file: {temp_log}{Colors.END}")
+    print(f"{Colors.GREEN}Analyzing log file once...{Colors.END}")
+    
+    # Analyze the log file
+    try:
+        analyze_log_file(temp_log, "qwen2.5-coder:0.5b")
+    except KeyboardInterrupt:
+        pass
+    
+    print(f"{Colors.GREEN}Demo 1 completed.{Colors.END}")
+    
+    # Clean up
+    try:
+        os.unlink(temp_log)
+    except:
+        pass
+    
+    return temp_log
+
+
+def demo_monitor_analyze():
+    """Demo monitoring a log file with analysis."""
+    print(f"\n{Colors.CYAN}{Colors.BOLD}DEMO 2: Monitor Log File with Analysis{Colors.END}")
+    
+    # Create a temporary log file
+    fd, temp_log = tempfile.mkstemp(suffix='.log')
+    os.close(fd)
+    
+    # Write initial content
+    with open(temp_log, 'w') as f:
+        f.write("[2025-04-13 10:15:00] Starting service...\n")
+    
+    print(f"{Colors.GREEN}Created test log file: {temp_log}{Colors.END}")
+    print(f"{Colors.GREEN}Starting log monitoring with analysis...{Colors.END}")
+    
+    # Start a thread to generate log entries
+    log_thread = threading.Thread(target=generate_log_entries, args=(temp_log,))
+    log_thread.daemon = True
+    
+    # Start monitoring in background
+    try:
+        monitor_log(temp_log, background=True, analyze=True)
+        log_thread.start()
+        time.sleep(10)  # Let it run for a bit
+    except KeyboardInterrupt:
+        pass
+    
+    print(f"{Colors.GREEN}Demo 2 completed.{Colors.END}")
+    
+    return temp_log
+
+
+def demo_monitor_watch():
+    """Demo monitoring a log file without analysis (just watching)."""
+    print(f"\n{Colors.CYAN}{Colors.BOLD}DEMO 3: Watch Log File without Analysis{Colors.END}")
+    
+    # Create a temporary log file
+    fd, temp_log = tempfile.mkstemp(suffix='.log')
+    os.close(fd)
+    
+    # Write initial content
+    with open(temp_log, 'w') as f:
+        f.write("[2025-04-13 10:30:00] Starting watch demo...\n")
+    
+    print(f"{Colors.GREEN}Created test log file: {temp_log}{Colors.END}")
+    print(f"{Colors.GREEN}Starting log monitoring without analysis (just watching)...{Colors.END}")
+    
+    # Start a thread to generate log entries
+    log_thread = threading.Thread(target=generate_log_entries, args=(temp_log,))
+    log_thread.daemon = True
+    
+    # Start monitoring in background
+    try:
+        monitor_log(temp_log, background=True, analyze=False)
+        log_thread.start()
+        time.sleep(10)  # Let it run for a bit
+    except KeyboardInterrupt:
+        pass
+    
+    print(f"{Colors.GREEN}Demo 3 completed.{Colors.END}")
+    
+    return temp_log
+
+
+def demo_list_monitors():
+    """Demo listing active monitors."""
+    print(f"\n{Colors.CYAN}{Colors.BOLD}DEMO 4: List Active Monitors{Colors.END}")
+    
+    print(f"{Colors.GREEN}Listing active monitors...{Colors.END}")
+    
+    # List active monitors (but don't ask for interactive options)
+    # This would show the monitors we created in previous demos
+    try:
+        if hasattr(list_active_log_monitors, '__wrapped__'):
+            # Use the original function if wrapped
+            list_active_log_monitors.__wrapped__()
+        else:
+            # Otherwise, we just print what we would do
+            print(f"{Colors.YELLOW}In a real execution, we would list all active monitors here.{Colors.END}")
+    except KeyboardInterrupt:
+        pass
+    
+    print(f"{Colors.GREEN}Demo 4 completed.{Colors.END}")
+
+
+def demo_view_monitor():
+    """Demo viewing a monitor."""
+    print(f"\n{Colors.CYAN}{Colors.BOLD}DEMO 5: View a Log Monitor{Colors.END}")
+    
+    # This would normally require user interaction to select a monitor ID
+    # For demo purposes, we'll just print instructions
+    print(f"{Colors.YELLOW}To view a monitor, you would use one of these commands:{Colors.END}")
+    print(f"{Colors.BLUE}qcmd --view-monitor SESSION_ID{Colors.END}")
+    print(f"{Colors.BLUE}or select a monitor number when running qcmd --list-monitors{Colors.END}")
+    
+    print(f"{Colors.GREEN}Demo 5 completed.{Colors.END}")
+
+
+def demo_stop_monitor():
+    """Demo stopping a monitor."""
+    print(f"\n{Colors.CYAN}{Colors.BOLD}DEMO 6: Stop a Log Monitor{Colors.END}")
+    
+    # This would normally require user interaction to select a monitor ID
+    # For demo purposes, we'll just print instructions
+    print(f"{Colors.YELLOW}To stop a monitor, you would use one of these commands:{Colors.END}")
+    print(f"{Colors.BLUE}qcmd --stop-monitor SESSION_ID{Colors.END}")
+    print(f"{Colors.BLUE}or select a monitor number when running qcmd --list-monitors{Colors.END}")
+    
+    print(f"{Colors.GREEN}Demo 6 completed.{Colors.END}")
+
+
+def demo_command_line():
+    """Show command line usage examples."""
+    print(f"\n{Colors.CYAN}{Colors.BOLD}COMMAND LINE USAGE EXAMPLES{Colors.END}")
+    
+    print(f"{Colors.YELLOW}Here are some command line examples:{Colors.END}")
+    print(f"{Colors.BLUE}# Analyze a log file once without monitoring{Colors.END}")
+    print(f"{Colors.BLUE}qcmd --logs --log-file /var/log/syslog --analyze-once{Colors.END}")
+    print()
+    
+    print(f"{Colors.BLUE}# Monitor a log file with analysis{Colors.END}")
+    print(f"{Colors.BLUE}qcmd --logs --log-file /var/log/syslog --monitor-analyze{Colors.END}")
+    print()
+    
+    print(f"{Colors.BLUE}# Monitor a log file without analysis (just watch){Colors.END}")
+    print(f"{Colors.BLUE}qcmd --logs --log-file /var/log/syslog --monitor-watch{Colors.END}")
+    print()
+    
+    print(f"{Colors.BLUE}# List active monitors{Colors.END}")
+    print(f"{Colors.BLUE}qcmd --list-monitors{Colors.END}")
+    print()
+    
+    print(f"{Colors.BLUE}# View a monitor{Colors.END}")
+    print(f"{Colors.BLUE}qcmd --view-monitor SESSION_ID{Colors.END}")
+    print()
+    
+    print(f"{Colors.BLUE}# Stop a monitor{Colors.END}")
+    print(f"{Colors.BLUE}qcmd --stop-monitor SESSION_ID{Colors.END}")
+    print()
+
+
+def cleanup(log_files):
+    """Clean up log files and stop any active monitors."""
+    print(f"\n{Colors.CYAN}{Colors.BOLD}CLEANING UP{Colors.END}")
+    
+    # Remove log files
+    for log_file in log_files:
+        try:
+            os.unlink(log_file)
+            print(f"{Colors.GREEN}Removed log file: {log_file}{Colors.END}")
+        except:
+            pass
+
+
+def main():
+    """Run all the demos."""
+    print(f"{Colors.CYAN}{Colors.BOLD}QCMD LOG MONITORING DEMOS{Colors.END}")
+    
+    try:
+        log_files = []
+        
+        # Demo 1: Analyze once
+        log_files.append(demo_analyze_once())
+        
+        # Demo 2: Monitor with analysis
+        log_files.append(demo_monitor_analyze())
+        
+        # Demo 3: Monitor without analysis
+        log_files.append(demo_monitor_watch())
+        
+        # Demo 4: List monitors
+        demo_list_monitors()
+        
+        # Demo 5: View monitor
+        demo_view_monitor()
+        
+        # Demo 6: Stop monitor
+        demo_stop_monitor()
+        
+        # Show command line examples
+        demo_command_line()
+        
+        # Clean up
+        cleanup(log_files)
+        
+        print(f"\n{Colors.GREEN}{Colors.BOLD}All demos completed successfully!{Colors.END}")
+        
+    except KeyboardInterrupt:
+        print(f"\n{Colors.YELLOW}Demo interrupted by user.{Colors.END}")
+    except Exception as e:
+        print(f"\n{Colors.RED}Error in demo: {e}{Colors.END}")
+
+
+if __name__ == "__main__":
+    main() 

--- a/demos/multi_log_dashboard.py
+++ b/demos/multi_log_dashboard.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Multi-log Dashboard Demo for QCMD.
+
+This script demonstrates how to set up monitoring for multiple log files
+and create a simple dashboard to view their status.
+"""
+
+import os
+import sys
+import time
+import tempfile
+import threading
+import subprocess
+import random
+
+# Add project root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Import needed modules
+from qcmd_cli.log_analysis.monitor import monitor_log
+from qcmd_cli.ui.display import Colors
+from qcmd_cli.log_analysis.log_files import list_active_log_monitors
+
+
+def create_test_log(name, initial_entries=3):
+    """Create a test log file with initial entries."""
+    fd, log_path = tempfile.mkstemp(prefix=f"qcmd_demo_{name}_", suffix='.log')
+    os.close(fd)
+    
+    log_types = ["INFO", "WARNING", "ERROR", "DEBUG"]
+    services = ["WebServer", "Database", "Authentication", "API", "Frontend"]
+    
+    with open(log_path, 'w') as f:
+        # Add header
+        f.write(f"# {name} Log File\n")
+        f.write("#" + "=" * 40 + "\n\n")
+        
+        # Add initial entries
+        for i in range(initial_entries):
+            timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+            log_type = random.choice(log_types)
+            service = random.choice(services)
+            
+            if log_type == "ERROR":
+                message = f"Failed to {random.choice(['connect', 'process', 'authenticate', 'validate'])} - {random.randint(1000, 9999)}"
+            elif log_type == "WARNING":
+                message = f"Unusual {random.choice(['activity', 'latency', 'usage', 'pattern'])} detected"
+            else:
+                message = f"Operation {random.choice(['completed', 'started', 'processed', 'queued'])} successfully"
+                
+            log_entry = f"[{timestamp}] [{service}] {log_type}: {message}\n"
+            f.write(log_entry)
+    
+    return log_path
+
+
+def generate_log_entries(log_path, interval=2, count=10, name=""):
+    """Generate random log entries for a log file."""
+    log_types = ["INFO", "WARNING", "ERROR", "DEBUG"]
+    weights = [0.6, 0.2, 0.15, 0.05]  # More common to have INFO entries
+    services = ["WebServer", "Database", "Authentication", "API", "Frontend"]
+    
+    for i in range(count):
+        try:
+            # Sleep randomly between updates
+            time.sleep(random.uniform(interval * 0.5, interval * 1.5))
+            
+            # Generate a random log entry
+            timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+            log_type = random.choices(log_types, weights=weights)[0]
+            service = random.choice(services)
+            
+            if log_type == "ERROR":
+                message = f"Failed to {random.choice(['connect', 'process', 'authenticate', 'validate'])} - {random.randint(1000, 9999)}"
+            elif log_type == "WARNING":
+                message = f"Unusual {random.choice(['activity', 'latency', 'usage', 'pattern'])} detected"
+            else:
+                message = f"Operation {random.choice(['completed', 'started', 'processed', 'queued'])} successfully"
+                
+            log_entry = f"[{timestamp}] [{service}] {log_type}: {message}\n"
+            
+            # Append to the log file
+            with open(log_path, 'a') as f:
+                f.write(log_entry)
+                
+            print(f"{Colors.BLUE}Added entry to {name} log: {log_type}{Colors.END}")
+        except Exception as e:
+            print(f"{Colors.RED}Error adding to {name} log: {e}{Colors.END}")
+
+
+def setup_multi_log_dashboard():
+    """Set up monitoring for multiple log files."""
+    print(f"{Colors.CYAN}{Colors.BOLD}QCMD Multi-Log Dashboard Demo{Colors.END}")
+    print(f"{Colors.CYAN}This demo will create multiple log files and monitor them simultaneously.{Colors.END}")
+    
+    # Create test log files
+    print(f"\n{Colors.GREEN}Creating test log files...{Colors.END}")
+    app_log = create_test_log("Application", 5)
+    db_log = create_test_log("Database", 3)
+    auth_log = create_test_log("Authentication", 4)
+    
+    print(f"{Colors.GREEN}Created log files:{Colors.END}")
+    print(f"  - Application Log: {app_log}")
+    print(f"  - Database Log: {db_log}")
+    print(f"  - Authentication Log: {auth_log}")
+    
+    # Start monitoring all logs
+    print(f"\n{Colors.GREEN}Starting monitors for all logs...{Colors.END}")
+    
+    # Monitor app log with analysis
+    print(f"{Colors.BLUE}Starting monitor for Application Log (with analysis)...{Colors.END}")
+    monitor_log(app_log, background=True, analyze=True, model="qwen2.5-coder:0.5b")
+    
+    # Monitor DB log with analysis
+    print(f"{Colors.BLUE}Starting monitor for Database Log (with analysis)...{Colors.END}")
+    monitor_log(db_log, background=True, analyze=True, model="qwen2.5-coder:0.5b")
+    
+    # Monitor Auth log without analysis (just watching)
+    print(f"{Colors.BLUE}Starting monitor for Authentication Log (watching only)...{Colors.END}")
+    monitor_log(auth_log, background=True, analyze=False)
+    
+    # Start threads to generate logs
+    print(f"\n{Colors.GREEN}Starting log generators...{Colors.END}")
+    
+    # Start a thread for each log file
+    app_thread = threading.Thread(
+        target=generate_log_entries, 
+        args=(app_log, 3, 20, "Application")
+    )
+    db_thread = threading.Thread(
+        target=generate_log_entries, 
+        args=(db_log, 4, 15, "Database")
+    )
+    auth_thread = threading.Thread(
+        target=generate_log_entries, 
+        args=(auth_log, 5, 12, "Authentication")
+    )
+    
+    app_thread.daemon = True
+    db_thread.daemon = True
+    auth_thread.daemon = True
+    
+    app_thread.start()
+    db_thread.start()
+    auth_thread.start()
+    
+    # Give time for some log entries to generate
+    print(f"\n{Colors.YELLOW}Generating log entries for 10 seconds...{Colors.END}")
+    time.sleep(10)
+    
+    # List active monitors (our dashboard)
+    print(f"\n{Colors.GREEN}{Colors.BOLD}Multi-Log Dashboard{Colors.END}")
+    list_active_log_monitors()
+    
+    # Instructions for the user
+    print(f"\n{Colors.GREEN}{Colors.BOLD}Demo completed!{Colors.END}")
+    print(f"{Colors.CYAN}You now have multiple log monitors running in the background.{Colors.END}")
+    print(f"{Colors.CYAN}You can:{Colors.END}")
+    print(f"  1. View any monitor: {Colors.BLUE}qcmd --list-monitors{Colors.END} then select 'v' and the monitor number")
+    print(f"  2. Stop any monitor: {Colors.BLUE}qcmd --list-monitors{Colors.END} then select 's' and the monitor number")
+    print(f"  3. Add more log entries manually:")
+    print(f"     {Colors.BLUE}echo \"[$(date)] [Service] ERROR: New test error\" >> {app_log}{Colors.END}")
+    
+    # For cleaner demo, return the log files for potential cleanup
+    return [app_log, db_log, auth_log]
+
+
+def main():
+    """Run the multi-log dashboard demo."""
+    try:
+        # Setup dashboard and get log file paths
+        log_files = setup_multi_log_dashboard()
+        
+        # Keep the main thread running to allow the demo to continue
+        print(f"\n{Colors.YELLOW}Press Ctrl+C to exit the demo...{Colors.END}")
+        while True:
+            time.sleep(1)
+            
+    except KeyboardInterrupt:
+        print(f"\n{Colors.YELLOW}Demo interrupted by user.{Colors.END}")
+    except Exception as e:
+        print(f"\n{Colors.RED}Error in demo: {e}{Colors.END}")
+    
+    # Note: We intentionally don't clean up the log files or stop the monitors
+    # so the user can continue to interact with them after the demo
+
+
+if __name__ == "__main__":
+    main() 

--- a/demos/quick_monitor_demo.sh
+++ b/demos/quick_monitor_demo.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Quick start demo for QCMD log monitoring
+
+# Create a test log file
+TEST_LOG="/tmp/qcmd_demo.log"
+echo "[$(date)] Starting application..." > $TEST_LOG
+echo "[$(date)] Initializing components..." >> $TEST_LOG
+echo "[$(date)] ERROR: Failed to connect to database" >> $TEST_LOG
+echo "[$(date)] Using fallback connection..." >> $TEST_LOG
+echo "[$(date)] Application ready" >> $TEST_LOG
+
+echo "Created test log file: $TEST_LOG"
+echo ""
+
+# Start monitoring in background
+echo "Starting log monitor in background..."
+qcmd --logs --log-file $TEST_LOG --monitor-analyze
+echo ""
+
+# Add more log entries
+echo "Adding more log entries to the monitored file..."
+sleep 2
+echo "[$(date)] Processing request #1234" >> $TEST_LOG
+sleep 2
+echo "[$(date)] ERROR: Invalid input received" >> $TEST_LOG
+sleep 2
+echo "[$(date)] Request #1234 failed" >> $TEST_LOG
+sleep 2
+echo "[$(date)] Processing request #1235" >> $TEST_LOG
+sleep 2
+echo "[$(date)] Request #1235 completed successfully" >> $TEST_LOG
+
+# List active monitors
+echo ""
+echo "Listing active monitors..."
+qcmd --list-monitors
+
+echo ""
+echo "Demo completed. You can:"
+echo "1. View the monitor output: qcmd --list-monitors (then select 'v' and the monitor number)"
+echo "2. Stop the monitor: qcmd --list-monitors (then select 's' and the monitor number)"
+echo "3. Add more log entries: echo \"[$(date)] New log entry\" >> $TEST_LOG"
+echo "" 

--- a/docs/log_monitor_sessions.md
+++ b/docs/log_monitor_sessions.md
@@ -1,0 +1,148 @@
+# Log Monitoring Sessions in QCMD
+
+This document describes the log monitoring session features in QCMD, which allow you to track, manage, and interact with log monitors.
+
+## Overview
+
+Log monitoring sessions in QCMD provide a way to:
+
+1. Monitor log files in real-time with AI-powered analysis
+2. Track active log monitors across multiple terminals
+3. Start background log monitors that persist even when you close your terminal
+4. View and manage all active log monitoring sessions
+
+## Command Line Usage
+
+### Starting a Log Monitor
+
+```bash
+# Analyze logs interactively with monitor options
+qcmd --logs
+
+# Monitor a specific log file
+qcmd --logs --log-file /var/log/syslog
+```
+
+### Managing Log Monitors
+
+```bash
+# List all active log monitors
+qcmd --list-monitors
+
+# Stop a specific log monitor by session ID
+qcmd --stop-monitor 3fa85f64-5717-4562-b3fc-2c963f66afa6
+```
+
+## Interactive Shell Commands
+
+When using the QCMD interactive shell (`qcmd --shell` or `qcmd -s`), you can use these commands:
+
+```
+/logs                     - Find and analyze log files or manage log monitors
+/list-monitors, /lm       - List active log monitoring sessions
+/stop-monitor ID, /sm ID  - Stop a log monitor by session ID
+/monitor PATH, /mon PATH  - Start monitoring a specific log file
+/status                   - Show system status including active log monitors
+```
+
+Example session:
+```
+qcmd> /logs
+# Choose a log file and monitoring option
+
+qcmd> /lm
+Active Log Monitors (2):
+1. syslog
+   Path: /var/log/syslog
+   Started: 2023-06-01 12:34:56
+   Model: qwen2.5-coder:0.5b
+   Mode: with analysis
+   Session ID: 3fa85f64...
+
+qcmd> /sm 3fa85f64-5717-4562-b3fc-2c963f66afa6
+Log monitor session ended.
+```
+
+## Interactive Mode
+
+When using the interactive log analysis menu (`qcmd --logs`), you'll see options to:
+
+1. View existing log monitors
+2. Stop active monitors
+3. Analyze log files
+4. Start new monitors
+
+## Technical Details
+
+### Session Management
+
+Each log monitor is tracked as a session with the following information:
+- Session ID (unique identifier)
+- Log file path
+- Start time
+- Process ID (PID)
+- Analysis model
+- Analysis mode
+
+### Monitor Types
+
+- **Foreground Monitors**: Run in the current terminal and show analysis results in real-time
+- **Background Monitors**: Run as separate processes that continue monitoring even if you close your terminal
+
+### Integration Points
+
+The log monitoring session system integrates with:
+- Process management
+- Session tracking
+- Signal handling
+- File system monitoring
+
+## Examples
+
+### Example 1: Monitor System Logs
+
+```bash
+# Start monitoring the system log in the background
+qcmd --logs --log-file /var/log/syslog
+# Choose option 3 when prompted
+```
+
+### Example 2: List and Manage Monitors
+
+```bash
+# List all active monitors
+qcmd --list-monitors
+
+# Output:
+# Active Log Monitors (2):
+# 1. syslog
+#    Path: /var/log/syslog
+#    Started: 2023-06-01 12:34:56
+#    Model: qwen2.5-coder:0.5b
+#    Mode: with analysis
+#    Session ID: 3fa85f64...
+
+# Stop a specific monitor
+qcmd --stop-monitor 3fa85f64-5717-4562-b3fc-2c963f66afa6
+```
+
+## Best Practices
+
+1. Use background monitors for long-term monitoring of critical logs
+2. Check for active monitors before starting new ones on the same file
+3. Properly stop monitors when they're no longer needed to free up resources
+4. Use the appropriate model for the type of log being analyzed
+
+## Troubleshooting
+
+If a monitor doesn't appear in the list of active monitors:
+1. The process may have crashed or been terminated
+2. The session file may be corrupted
+3. You may not have permission to access the session information
+
+To clean up stale monitors, use:
+```bash
+qcmd --logs
+# Then select option to stop monitors
+```
+

--- a/qcmd_cli/commands/handler.py
+++ b/qcmd_cli/commands/handler.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Any, Optional
 
 # Import from other modules
 from ..core.interactive_shell import start_interactive_shell, auto_mode
-from ..log_analysis.log_files import handle_log_analysis
+from ..log_analysis.log_files import handle_log_analysis, list_active_log_monitors, stop_log_monitor, view_monitor, open_session_monitor
 from ..utils.system import display_system_status, check_for_updates
 from ..config.settings import handle_config_command, load_config
 from ..core.command_generator import generate_command, execute_command, list_models
@@ -61,6 +61,22 @@ def parse_args():
                        help='Analyze log files')
     parser.add_argument('--log-file', type=str,
                        help='Specify a log file to analyze')
+    parser.add_argument('--analyze-once', action='store_true',
+                       help='Analyze the log file once (no monitoring)')
+    parser.add_argument('--monitor-analyze', action='store_true',
+                       help='Monitor the log file with analysis')
+    parser.add_argument('--monitor-watch', action='store_true',
+                       help='Monitor the log file without analysis (just watch)')
+    parser.add_argument('--list-monitors', action='store_true',
+                       help='List active log monitors')
+    parser.add_argument('--stop-monitor', type=str,
+                       help='Stop a log monitor by session ID')
+    parser.add_argument('--view-monitor', type=str,
+                       help='View a running monitor by session ID')
+    parser.add_argument('--open-monitor', action='store_true',
+                       help='Open a log monitor - will show list of active monitors and let you select one')
+    parser.add_argument('--analysis-only', action='store_true',
+                       help='When viewing monitors, only show analysis results without raw log lines')
     
     # Configuration options
     parser.add_argument('--model', type=str, default=None,
@@ -141,7 +157,30 @@ def main():
         
     # If analyzing logs
     if args.logs:
-        handle_log_analysis(args.model, args.log_file)
+        handle_log_analysis(args.model, args.log_file, 
+                          analyze_once=args.analyze_once,
+                          monitor_analyze=args.monitor_analyze,
+                          monitor_watch=args.monitor_watch)
+        return
+    
+    # If listing active log monitors
+    if args.list_monitors:
+        list_active_log_monitors()
+        return
+
+    # If stopping a log monitor
+    if args.stop_monitor:
+        stop_log_monitor(args.stop_monitor)
+        return
+        
+    # If viewing a log monitor
+    if args.view_monitor:
+        view_monitor(args.view_monitor, show_analysis_only=args.analysis_only)
+        return
+    
+    # If opening a monitor interactively
+    if args.open_monitor:
+        open_session_monitor(show_analysis_only=args.analysis_only)
         return
     
     # Display minimal banner for main operations

--- a/qcmd_cli/core/interactive_shell.py
+++ b/qcmd_cli/core/interactive_shell.py
@@ -22,7 +22,7 @@ from qcmd_cli.ui.display import Colors, print_cool_header, clear_screen
 from qcmd_cli.core.command_generator import generate_command, is_dangerous_command, list_models, fix_command
 from qcmd_cli.utils.history import save_to_history, load_history, show_history
 from qcmd_cli.utils.system import execute_command, get_system_status, display_update_status, display_system_status
-from qcmd_cli.log_analysis.log_files import handle_log_analysis
+from qcmd_cli.log_analysis.log_files import handle_log_analysis, list_active_log_monitors, stop_log_monitor
 from qcmd_cli.log_analysis.analyzer import analyze_log_file
 from qcmd_cli.utils.ollama import is_ollama_running
 
@@ -268,6 +268,21 @@ def start_interactive_shell(
                     handle_log_analysis(current_model)
                     continue
                     
+                elif user_input.lower() in ('/list-monitors', '/lm'):
+                    # List active log monitors
+                    list_active_log_monitors()
+                    continue
+                    
+                elif user_input.lower().startswith('/stop-monitor ') or user_input.lower().startswith('/sm '):
+                    # Stop a log monitor by session ID
+                    parts = user_input.split(maxsplit=1)
+                    if len(parts) == 2:
+                        session_id = parts[1]
+                        stop_log_monitor(session_id)
+                    else:
+                        print(f"{Colors.YELLOW}Usage: /stop-monitor <session_id> or /sm <session_id>{Colors.END}")
+                    continue
+                    
                 elif user_input.lower().startswith('/analyze-file '):
                     # Analyze a specific file
                     parts = user_input.split(maxsplit=1)
@@ -281,7 +296,7 @@ def start_interactive_shell(
                         print(f"{Colors.YELLOW}Usage: /analyze-file <file_path>{Colors.END}")
                     continue
                     
-                elif user_input.lower().startswith('/monitor '):
+                elif user_input.lower().startswith('/monitor ') or user_input.lower().startswith('/mon '):
                     # Monitor a specific file with AI analysis
                     parts = user_input.split(maxsplit=1)
                     if len(parts) == 2:
@@ -291,7 +306,7 @@ def start_interactive_shell(
                         else:
                             print(f"{Colors.YELLOW}File not found: {file_path}{Colors.END}")
                     else:
-                        print(f"{Colors.YELLOW}Usage: /monitor <file_path>{Colors.END}")
+                        print(f"{Colors.YELLOW}Usage: /monitor <file_path> or /mon <file_path>{Colors.END}")
                     continue
                     
                 elif user_input.lower() == '/execute':
@@ -477,9 +492,11 @@ def _show_shell_help() -> None:
     print(f"{Colors.YELLOW}/manual{Colors.END} - Disable auto mode")
     print(f"{Colors.YELLOW}/analyze{Colors.END} - Toggle error analysis")
     print(f"{Colors.YELLOW}/execute{Colors.END} - Execute last generated command (with confirmation)")
-    print(f"{Colors.YELLOW}/logs{Colors.END} - Find and analyze log files")
+    print(f"{Colors.YELLOW}/logs{Colors.END} - Find and analyze log files or manage log monitors")
+    print(f"{Colors.YELLOW}/list-monitors{Colors.END}, {Colors.YELLOW}/lm{Colors.END} - List active log monitoring sessions")
+    print(f"{Colors.YELLOW}/stop-monitor <id>{Colors.END}, {Colors.YELLOW}/sm <id>{Colors.END} - Stop a log monitor by session ID")
     print(f"{Colors.YELLOW}/analyze-file <path>{Colors.END} - Analyze a specific file")
-    print(f"{Colors.YELLOW}/monitor <path>{Colors.END} - Monitor a file continuously")
+    print(f"{Colors.YELLOW}/monitor <path>{Colors.END}, {Colors.YELLOW}/mon <path>{Colors.END} - Monitor a file continuously")
     
     print(f"\n{Colors.CYAN}Command Execution Options:{Colors.END}")
     print(f"When a command is generated, you'll be presented with these options:")

--- a/qcmd_cli/log_analysis/cli/__init__.py
+++ b/qcmd_cli/log_analysis/cli/__init__.py
@@ -1,0 +1,3 @@
+"""
+Command-line interface tools for log analysis and monitoring.
+""" 

--- a/qcmd_cli/log_analysis/cli/view_monitor.py
+++ b/qcmd_cli/log_analysis/cli/view_monitor.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Command-line tool for viewing active log monitors.
+This allows users to easily connect to any active log monitor session
+to see real-time log entries and analysis.
+"""
+import os
+import sys
+import argparse
+from typing import List, Dict, Optional, Any
+
+# Add the parent directory to path to import modules
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..')))
+
+from qcmd_cli.log_analysis.log_files import open_session_monitor, list_active_log_monitors
+from qcmd_cli.ui.display import Colors, print_cool_header
+
+def parse_args():
+    """
+    Parse command-line arguments.
+    
+    Returns:
+        The parsed command-line arguments
+    """
+    parser = argparse.ArgumentParser(
+        description='View and connect to active log monitors',
+    )
+    
+    parser.add_argument('-l', '--list', action='store_true',
+                       help='Only list active monitors without connecting')
+    parser.add_argument('-s', '--session-id', type=str,
+                       help='Directly connect to a specific session ID')
+    parser.add_argument('-a', '--analysis-only', action='store_true',
+                       help='Only show analysis results without raw log lines')
+    parser.add_argument('-f', '--full-display', action='store_true',
+                       help='Show both raw log lines and analysis (default)')
+    
+    return parser.parse_args()
+
+def main():
+    """
+    Main entry point for the log monitor viewer.
+    """
+    args = parse_args()
+    
+    # Print a simple header
+    print_cool_header("QCMD Log Monitor Viewer")
+    
+    # Determine display mode
+    show_analysis_only = args.analysis_only
+    if args.full_display:
+        show_analysis_only = False
+    
+    # If session ID is provided, connect directly to that monitor
+    if args.session_id:
+        print(f"{Colors.CYAN}Connecting to monitor session: {args.session_id}{Colors.END}")
+        if show_analysis_only:
+            print(f"{Colors.YELLOW}Display mode: Analysis only (log lines hidden){Colors.END}")
+        else:
+            print(f"{Colors.YELLOW}Display mode: Full (showing log lines and analysis){Colors.END}")
+        open_session_monitor(args.session_id, show_analysis_only)
+        return
+    
+    # If only listing is requested, show the list and exit
+    if args.list:
+        print(f"{Colors.CYAN}Listing active log monitors:{Colors.END}")
+        list_active_log_monitors(non_interactive=True)
+        return
+    
+    # Otherwise, show the interactive list of monitors
+    print(f"{Colors.CYAN}Select a monitor to connect to:{Colors.END}")
+    if show_analysis_only:
+        print(f"{Colors.YELLOW}Display mode: Analysis only (log lines hidden){Colors.END}")
+    else:
+        print(f"{Colors.YELLOW}Display mode: Full (showing log lines and analysis){Colors.END}")
+    print(f"{Colors.GREEN}Note: Press 'm' while viewing to toggle between display modes.{Colors.END}")
+    open_session_monitor(show_analysis_only=show_analysis_only)
+
+if __name__ == "__main__":
+    main() 

--- a/qcmd_cli/log_analysis/log_files.py
+++ b/qcmd_cli/log_analysis/log_files.py
@@ -7,11 +7,14 @@ import json
 import time
 import tempfile
 import subprocess
+import signal
 from typing import List, Optional, Dict, Any
 
 from ..config.settings import DEFAULT_MODEL, CONFIG_DIR
 from ..ui.display import Colors
 from .analyzer import analyze_log_file, analyze_log_content, read_large_file
+from .monitor import load_monitors, save_monitors, cleanup_stale_monitors
+from ..utils.session import get_active_log_monitors, end_session, load_sessions
 
 # Cache settings
 LOG_CACHE_FILE = os.path.join(CONFIG_DIR, "log_cache.json")
@@ -220,27 +223,157 @@ def display_log_selection(log_files: List[str]) -> Optional[str]:
             print(f"\n{Colors.YELLOW}Operation cancelled.{Colors.END}")
             return None
 
-def handle_log_analysis(model: str = DEFAULT_MODEL, file_path: str = None) -> None:
+def handle_log_analysis(model: str = DEFAULT_MODEL, file_path: str = None, 
+                       analyze_once: bool = False, monitor_analyze: bool = False,
+                       monitor_watch: bool = False, auto_continue: bool = False) -> None:
     """
-    Main entry point for log analysis feature.
+    Main entry point for log analysis functionality.
     
     Args:
         model: The model to use for analysis
-        file_path: Optional path to a specific file to analyze
+        file_path: Optional path to a specific log file to analyze
+        analyze_once: Analyze the log file once without monitoring
+        monitor_analyze: Monitor the log file with analysis
+        monitor_watch: Monitor the log file without analysis (just watch)
+        auto_continue: Automatically continue without asking in test mode
     """
-    print(f"{Colors.GREEN}Starting log analysis tool...{Colors.END}")
+    # Import here to avoid circular imports
+    from .analyzer import analyze_log_file
+    from .monitor import monitor_log
     
-    # If a specific file is provided, analyze it directly
+    print("Starting log analysis tool...")
+    
+    # If a log file was specified, analyze it directly
     if file_path:
         if os.path.exists(file_path) and os.path.isfile(file_path):
-            # Ask if user wants continuous monitoring
-            monitor = input(f"{Colors.GREEN}Monitor this file continuously? (y/n): {Colors.END}").lower()
+            if analyze_once:
+                analyze_log_file(file_path, model)
+            elif monitor_analyze:
+                monitor_log(file_path, background=True, analyze=True, model=model)
+            elif monitor_watch:
+                monitor_log(file_path, background=True, analyze=False, model=model)
+            else:
+                handle_log_selection(file_path, model, analyze_once, monitor_analyze, monitor_watch)
+            return
+        elif file_path.startswith("journalctl:"):
+            # For journalctl service logs
+            service_name = file_path.split(':', 1)[1]
             
-            # Analyze the specified file
-            analyze_log_file(file_path, model, monitor in ['y', 'yes'])
+            try:
+                # Create a temp file for the journal output
+                with tempfile.NamedTemporaryFile(delete=False, mode='w+t', suffix='.log') as temp_file:
+                    temp_path = temp_file.name
+                    
+                    # Get the journal output
+                    journal_output = subprocess.check_output(
+                        ["journalctl", "-u", service_name], 
+                        universal_newlines=True
+                    )
+                    
+                    # Write to temp file
+                    temp_file.write(journal_output)
+                
+                print(f"{Colors.GREEN}Retrieved logs for service {service_name}.{Colors.END}")
+                
+                # Analyze the temp file
+                if analyze_once:
+                    analyze_log_file(temp_path, model)
+                elif monitor_analyze:
+                    monitor_log(temp_path, background=True, analyze=True, model=model)
+                elif monitor_watch:
+                    monitor_log(temp_path, background=True, analyze=False, model=model)
+                else:
+                    handle_log_selection(temp_path, model, analyze_once, monitor_analyze, monitor_watch)
+                
+                # Clean up
+                try:
+                    os.unlink(temp_path)
+                except:
+                    pass
+                    
+            except subprocess.SubprocessError as e:
+                print(f"{Colors.RED}Error fetching service logs: {e}{Colors.END}")
+            except Exception as e:
+                print(f"{Colors.RED}Error: {e}{Colors.END}")
         else:
-            print(f"{Colors.RED}Error: File {file_path} does not exist or is not accessible.{Colors.END}")
-        return
+            # Regular file
+            if os.path.exists(file_path) and os.path.isfile(file_path):
+                if analyze_once:
+                    analyze_log_file(file_path, model)
+                elif monitor_analyze:
+                    monitor_log(file_path, background=True, analyze=True, model=model)
+                elif monitor_watch:
+                    monitor_log(file_path, background=True, analyze=False, model=model)
+                else:
+                    handle_log_selection(file_path, model, analyze_once, monitor_analyze, monitor_watch)
+            else:
+                print(f"{Colors.RED}Error: File {file_path} does not exist or is not accessible.{Colors.END}")
+            return
+    
+    # First, show active log monitors
+    has_monitors = list_active_log_monitors()
+    
+    # If we want to manage monitors
+    if has_monitors:
+        if auto_continue:
+            monitor_action = 'c'  # Automatically continue in test mode
+        else:
+            monitor_action = input(f"{Colors.GREEN}Do you want to (s)top a monitor, (v)iew logs, or (c)ontinue to analyze new logs? [s/v/c]: {Colors.END}").lower()
+    else:
+        monitor_action = 'c'  # Default to continue if no monitors
+    
+    if monitor_action == 's':
+        # Get active log monitor sessions and legacy monitors
+        log_monitors = get_active_log_monitors()
+        legacy_monitors = load_monitors()
+        
+        # Combine both types into a single dictionary for easier handling
+        all_monitors = {}
+        
+        # Add session-based monitors
+        for i, (session_id, info) in enumerate(log_monitors.items(), 1):
+            log_file = info.get('log_file', 'Unknown')
+            all_monitors[i] = {
+                'id': session_id,
+                'type': 'session',
+                'name': os.path.basename(log_file)
+            }
+        
+        # Add legacy monitors
+        offset = len(log_monitors)
+        for i, (monitor_id, info) in enumerate(legacy_monitors.items(), offset + 1):
+            log_file = info.get('log_file', 'Unknown')
+            all_monitors[i] = {
+                'id': monitor_id,
+                'type': 'legacy',
+                'name': os.path.basename(log_file)
+            }
+        
+        if not all_monitors:
+            print(f"{Colors.YELLOW}No active log monitors to stop.{Colors.END}")
+        else:
+            # Display monitors with numbers
+            for i, info in all_monitors.items():
+                monitor_id = info['id']
+                name = info['name']
+                id_type = info['type']
+                print(f"{i}. {name} ({monitor_id[:8]}... - {id_type})")
+            
+            # Ask which one to stop
+            try:
+                choice = int(input(f"{Colors.GREEN}Enter number to stop (or 0 to cancel): {Colors.END}"))
+                if choice > 0 and choice in all_monitors:
+                    monitor_info = all_monitors[choice]
+                    stop_log_monitor(monitor_info['id'])
+                elif choice != 0:
+                    print(f"{Colors.YELLOW}Invalid selection.{Colors.END}")
+            except (ValueError, IndexError):
+                print(f"{Colors.YELLOW}Invalid selection.{Colors.END}")
+        
+        # Return to main menu or continue with analysis
+        continue_analysis = input(f"{Colors.GREEN}Do you want to analyze logs now? (y/n): {Colors.END}").lower()
+        if continue_analysis != 'y':
+            return
     
     # Find log files
     log_files = find_log_files()
@@ -252,113 +385,76 @@ def handle_log_analysis(model: str = DEFAULT_MODEL, file_path: str = None) -> No
     # Let user select a log file
     selected_log = display_log_selection(log_files)
     
-    if not selected_log:
-        return
-        
-    # Special handling for journalctl entries
-    if selected_log.startswith("journalctl:"):
-        service_name = selected_log[11:]
-        print(f"{Colors.GREEN}Fetching logs for service: {Colors.BOLD}{service_name}{Colors.END}")
-        
-        try:
-            # Create a temporary file to store the logs
-            with tempfile.NamedTemporaryFile(delete=False, mode='w+') as temp_file:
-                # Get logs from journalctl
-                logs = subprocess.check_output(
-                    ["journalctl", "-u", service_name, "--no-pager", "-n", "1000"],
-                    stderr=subprocess.DEVNULL,
-                    universal_newlines=True
-                )
-                temp_file.write(logs)
-                temp_file_path = temp_file.name
-            
-            # Ask if user wants continuous monitoring
-            monitor = input(f"{Colors.GREEN}Monitor this service log continuously? (y/n): {Colors.END}").lower()
-            
-            # Analyze the log file
-            analyze_log_file(temp_file_path, model, monitor in ['y', 'yes'])
-            
-            # Clean up temp file if not in continuous mode
-            if monitor not in ['y', 'yes']:
-                try:
-                    os.unlink(temp_file_path)
-                except:
-                    pass
-                    
-        except subprocess.SubprocessError as e:
-            print(f"{Colors.RED}Error fetching service logs: {e}{Colors.END}")
-        except Exception as e:
-            print(f"{Colors.RED}Error: {e}{Colors.END}")
-            
-    else:
-        # Ask if user wants continuous monitoring
-        monitor = input(f"{Colors.GREEN}Monitor this log file continuously? (y/n): {Colors.END}").lower()
-        
-        # Analyze the selected log file
-        analyze_log_file(selected_log, model, monitor in ['y', 'yes'])
+    if selected_log:
+        handle_log_selection(selected_log, model, analyze_once, monitor_analyze, monitor_watch)
 
-def handle_log_selection(selected_log: str, model: str) -> None:
+def handle_log_selection(selected_log: str, model: str,
+                       analyze_once: bool = False, 
+                       monitor_analyze: bool = False,
+                       monitor_watch: bool = False) -> None:
     """
-    Handle a selected log file from the all-logs menu.
+    Handle log file selection and analysis options.
     
     Args:
-        selected_log: The selected log file path or journalctl service
+        selected_log: Path to the selected log file
         model: The model to use for analysis
+        analyze_once: Analyze the log file once without monitoring
+        monitor_analyze: Monitor the log file with analysis
+        monitor_watch: Monitor the log file without analysis (just watch)
     """
-    if not selected_log:
-        return
-        
-    # Ask if user wants to analyze, monitor with analysis, or just watch the selected log
-    action = input(f"{Colors.GREEN}Do you want to (a)nalyze once, (m)onitor with analysis, or just (w)atch without analysis? (a/m/w): {Colors.END}").lower()
-    is_monitor = action.startswith('m')
-    is_watch = action.startswith('w')
-    analyze = not is_watch  # True for analyze and monitor, False for watch
-    background = is_monitor or is_watch  # True for both monitoring options
-    
-    # Special handling for journalctl entries
+    # Import here to avoid circular imports
+    from .analyzer import analyze_log_file
+    from .monitor import monitor_log
+
+    # Check if the log is a journalctl service
     if selected_log.startswith("journalctl:"):
-        service_name = selected_log[11:]
-        print(f"{Colors.GREEN}Fetching logs for service: {Colors.BOLD}{service_name}{Colors.END}")
+        service_name = selected_log.split(':', 1)[1]
         
         try:
-            # Create a temporary file to store the logs
-            with tempfile.NamedTemporaryFile(delete=False, mode='w+') as temp_file:
-                try:
-                    # Get logs from journalctl with timeout
-                    logs = subprocess.check_output(
-                        ["journalctl", "-u", service_name, "--no-pager", "-n", "1000"],
-                        stderr=subprocess.DEVNULL,
-                        universal_newlines=True,
-                        timeout=10  # Add timeout of 10 seconds
-                    )
-                    temp_file.write(logs)
-                    temp_file_path = temp_file.name
-                except subprocess.TimeoutExpired:
-                    print(f"{Colors.RED}Error: journalctl command timed out.{Colors.END}")
-                    print(f"{Colors.YELLOW}The service logs might be too large or the system is busy.{Colors.END}")
-                    try:
-                        os.unlink(temp_file.name)
-                    except:
-                        pass
-                    return
-                except FileNotFoundError:
-                    print(f"{Colors.RED}Error: journalctl command not found.{Colors.END}")
-                    print(f"{Colors.YELLOW}This system might not use systemd or journalctl isn't installed.{Colors.END}")
-                    try:
-                        os.unlink(temp_file.name)
-                    except:
-                        pass
-                    return
+            # Create a temp file for the journal output
+            with tempfile.NamedTemporaryFile(delete=False, mode='w+t', suffix='.log') as temp_file:
+                temp_path = temp_file.name
+                
+                # Get the journal output
+                journal_output = subprocess.check_output(
+                    ["journalctl", "-u", service_name], 
+                    universal_newlines=True
+                )
+                
+                # Write to temp file
+                temp_file.write(journal_output)
             
-            # Analyze the log file
-            analyze_log_file(temp_file_path, model, background, analyze)
+            print(f"{Colors.GREEN}Retrieved logs for service {service_name}.{Colors.END}")
             
-            # Clean up temp file if not in continuous mode
-            if not background:
-                try:
-                    os.unlink(temp_file_path)
-                except:
-                    pass
+            # Based on the automatic options or user choice
+            if analyze_once:
+                action = 'a'  # Analyze once
+            elif monitor_analyze:
+                action = 'm'  # Monitor with analysis
+            elif monitor_watch:
+                action = 'w'  # Watch without analysis
+            else:
+                # Ask user what they want to do
+                action = input(f"{Colors.GREEN}Do you want to (a)nalyze once, (m)onitor with analysis, or just (w)atch without analysis? (a/m/w): {Colors.END}").lower()
+            
+            if action == 'a':
+                # Analyze once
+                analyze_log_file(temp_path, model)
+            elif action == 'm':
+                # Monitor with analysis
+                monitor_log(temp_path, background=True, analyze=True, model=model)
+            elif action == 'w':
+                # Watch without analysis
+                monitor_log(temp_path, background=True, analyze=False, model=model)
+            else:
+                print(f"{Colors.YELLOW}Invalid choice. Analyzing once.{Colors.END}")
+                analyze_log_file(temp_path, model)
+            
+            # Clean up
+            try:
+                os.unlink(temp_path)
+            except:
+                pass
                     
         except subprocess.SubprocessError as e:
             print(f"{Colors.RED}Error fetching service logs: {e}{Colors.END}")
@@ -367,6 +463,330 @@ def handle_log_selection(selected_log: str, model: str) -> None:
     else:
         # Regular file
         if os.path.exists(selected_log) and os.path.isfile(selected_log):
-            analyze_log_file(selected_log, model, background, analyze)
+            # Based on the automatic options or user choice
+            if analyze_once:
+                action = 'a'  # Analyze once
+            elif monitor_analyze:
+                action = 'm'  # Monitor with analysis
+            elif monitor_watch:
+                action = 'w'  # Watch without analysis
+            else:
+                # Ask user what they want to do
+                action = input(f"{Colors.GREEN}Do you want to (a)nalyze once, (m)onitor with analysis, or just (w)atch without analysis? (a/m/w): {Colors.END}").lower()
+            
+            if action == 'a':
+                # Analyze once
+                analyze_log_file(selected_log, model)
+            elif action == 'm':
+                # Monitor with analysis
+                monitor_log(selected_log, background=True, analyze=True, model=model)
+            elif action == 'w':
+                # Watch without analysis
+                monitor_log(selected_log, background=True, analyze=False, model=model)
+            else:
+                print(f"{Colors.YELLOW}Invalid choice. Analyzing once.{Colors.END}")
+                analyze_log_file(selected_log, model)
         else:
             print(f"{Colors.RED}Error: File {selected_log} does not exist or is not accessible.{Colors.END}") 
+
+def list_active_log_monitors(non_interactive=False):
+    """
+    Display a list of currently active log monitors.
+    
+    Args:
+        non_interactive: If True, don't prompt for user action
+        
+    Returns:
+        False if no monitors found, True otherwise
+    """
+    # Get active log monitor sessions
+    log_monitors = get_active_log_monitors()
+    
+    # Also check legacy monitors for backward compatibility
+    legacy_monitors = cleanup_stale_monitors()
+    legacy_count = len(legacy_monitors)
+    
+    total_count = len(log_monitors) + legacy_count
+    
+    if total_count == 0:
+        print(f"{Colors.YELLOW}No active log monitors found.{Colors.END}")
+        return False
+    
+    print(f"\n{Colors.GREEN}{Colors.BOLD}Active Log Monitors ({total_count}):{Colors.END}")
+    
+    # Create a mapping of display index to session/monitor ID
+    index_to_id = {}
+    
+    # Display session-based monitors
+    for i, (session_id, info) in enumerate(log_monitors.items(), 1):
+        log_file = info.get('log_file', 'Unknown')
+        started_at = info.get('start_time', 'Unknown')
+        model = info.get('model', 'Unknown')
+        analyze = "with analysis" if info.get('analyze', True) else "without analysis"
+        
+        print(f"{i}. {Colors.CYAN}{os.path.basename(log_file)}{Colors.END}")
+        print(f"   {Colors.BLUE}Path:{Colors.END} {log_file}")
+        print(f"   {Colors.BLUE}Started:{Colors.END} {started_at}")
+        print(f"   {Colors.BLUE}Model:{Colors.END} {model}")
+        print(f"   {Colors.BLUE}Mode:{Colors.END} {analyze}")
+        print(f"   {Colors.BLUE}Session ID:{Colors.END} {session_id[:8]}...")
+        print()
+        
+        # Store the mapping
+        index_to_id[i] = session_id
+    
+    # Display legacy monitors if any
+    if legacy_count > 0:
+        print(f"\n{Colors.YELLOW}{Colors.BOLD}Legacy Monitors (Pre-Session System):{Colors.END}")
+        offset = len(log_monitors)
+        for i, (monitor_id, info) in enumerate(legacy_monitors.items(), offset + 1):
+            log_file = info.get('log_file', 'Unknown')
+            pid = info.get('pid', 'Unknown')
+            started_at = info.get('started_at', 'Unknown')
+            
+            print(f"{i}. {Colors.CYAN}{os.path.basename(log_file)}{Colors.END}")
+            print(f"   {Colors.BLUE}Path:{Colors.END} {log_file}")
+            print(f"   {Colors.BLUE}Started:{Colors.END} {started_at}")
+            print(f"   {Colors.BLUE}PID:{Colors.END} {pid}")
+            print(f"   {Colors.BLUE}Monitor ID:{Colors.END} {monitor_id}")
+            print()
+            
+            # Store the mapping
+            index_to_id[i] = monitor_id
+    
+    # Skip interactive prompts if non_interactive is True
+    if non_interactive:
+        return True
+        
+    # Ask user if they want to take action
+    try:
+        print(f"{Colors.CYAN}=== Monitor Options ==={Colors.END}")
+        print(f"  {Colors.GREEN}v{Colors.END} - View a monitor (connect to see live log entries and analysis)")
+        print(f"  {Colors.GREEN}s{Colors.END} - Stop a monitor")
+        print(f"  {Colors.GREEN}c{Colors.END} - Continue to analyze new logs")
+        print(f"  {Colors.GREEN}f{Colors.END} - Full display mode (show both log entries and analysis)")
+        print(f"  {Colors.GREEN}a{Colors.END} - Analysis-only mode (hide raw log entries)")
+        action = input(f"{Colors.GREEN}What would you like to do? [v/s/c/f/a]: {Colors.END}").lower()
+        
+        if action == 's':
+            # Stop a monitor
+            try:
+                monitor_num = int(input(f"{Colors.GREEN}Enter monitor number to stop: {Colors.END}"))
+                if monitor_num in index_to_id:
+                    stop_log_monitor(index_to_id[monitor_num])
+                else:
+                    print(f"{Colors.RED}Invalid monitor number.{Colors.END}")
+            except ValueError:
+                print(f"{Colors.RED}Invalid input. Please enter a number.{Colors.END}")
+        elif action == 'v' or action == 'f' or action == 'a':
+            # View monitor with specific display mode
+            try:
+                monitor_num = int(input(f"{Colors.GREEN}Enter monitor number to view: {Colors.END}"))
+                if monitor_num in index_to_id:
+                    # Default to normal view mode for 'v', analysis only for 'a', full display for 'f'
+                    show_analysis_only = (action == 'a')
+                    if show_analysis_only:
+                        print(f"{Colors.GREEN}Viewing in analysis-only mode (log lines hidden){Colors.END}")
+                    else:
+                        print(f"{Colors.GREEN}Viewing in full display mode (showing log lines and analysis){Colors.END}")
+                    view_monitor(index_to_id[monitor_num], show_analysis_only=show_analysis_only)
+                else:
+                    print(f"{Colors.RED}Invalid monitor number.{Colors.END}")
+            except ValueError:
+                print(f"{Colors.RED}Invalid input. Please enter a number.{Colors.END}")
+    except KeyboardInterrupt:
+        print("\nCancelled.")
+    
+    return True
+
+def stop_log_monitor(session_id):
+    """
+    Stop a log monitor by its session ID or monitor ID.
+    
+    Args:
+        session_id: ID of the session or monitor to stop
+        
+    Returns:
+        True if the monitor was stopped, False otherwise
+    """
+    # First check session-based monitors
+    sessions = load_sessions()
+    
+    if session_id in sessions:
+        info = sessions[session_id]
+        
+        if info.get('type') != 'log_monitor':
+            print(f"{Colors.RED}Error: Not a log monitor session.{Colors.END}")
+            return False
+        
+        # Get the process ID
+        pid = info.get('pid')
+        
+        if pid:
+            try:
+                # Send termination signal to the process
+                os.kill(pid, signal.SIGTERM)
+                print(f"{Colors.GREEN}Sent termination signal to log monitor process.{Colors.END}")
+            except OSError:
+                # Process might not exist anymore
+                pass
+        
+        # End the session in any case
+        end_session(session_id)
+        print(f"{Colors.GREEN}Log monitor session ended.{Colors.END}")
+        return True
+    
+    # If not found in sessions, check legacy monitors
+    monitors = load_monitors()
+    
+    if session_id in monitors:
+        info = monitors[session_id]
+        
+        # Get the process ID
+        pid = info.get('pid')
+        
+        if pid:
+            try:
+                # Send termination signal to the process
+                os.kill(pid, signal.SIGTERM)
+                print(f"{Colors.GREEN}Sent termination signal to legacy monitor process.{Colors.END}")
+            except OSError:
+                # Process might not exist anymore
+                pass
+        
+        # Remove from monitors
+        del monitors[session_id]
+        save_monitors(monitors)
+        
+        # Also end associated session if it exists
+        if 'session_id' in info:
+            try:
+                end_session(info['session_id'])
+            except:
+                pass
+        
+        print(f"{Colors.GREEN}Legacy monitor ended.{Colors.END}")
+        return True
+    
+    print(f"{Colors.RED}Error: No monitor found with ID {session_id}.{Colors.END}")
+    return False
+
+def view_monitor(session_id, show_analysis_only=False):
+    """
+    View the output of a running monitor by connecting to it.
+    
+    Args:
+        session_id: ID of the session or monitor to view
+        show_analysis_only: If True, only show analysis without raw log lines
+        
+    Returns:
+        True if the monitor was found and connected to, False otherwise
+    """
+    # First check session-based monitors
+    sessions = load_sessions()
+    
+    if session_id in sessions:
+        info = sessions[session_id]
+        
+        if info.get('type') != 'log_monitor':
+            print(f"{Colors.RED}Error: Not a log monitor session.{Colors.END}")
+            return False
+        
+        # Get the log file
+        log_file = info.get('log_file')
+        model = info.get('model', 'qwen2.5-coder:0.5b')
+        analyze = info.get('analyze', True)
+        
+        if not log_file or not os.path.exists(log_file):
+            print(f"{Colors.RED}Error: Log file no longer exists.{Colors.END}")
+            return False
+        
+        print(f"{Colors.GREEN}Connecting to monitor for {log_file}...{Colors.END}")
+        from .monitor import monitor_log
+        
+        # Start monitoring in foreground mode (will show output)
+        monitor_log(log_file, background=False, analyze=analyze, model=model, 
+                   show_analysis_only=show_analysis_only)
+        return True
+    
+    # If not found in sessions, check legacy monitors
+    monitors = load_monitors()
+    
+    if session_id in monitors:
+        info = monitors[session_id]
+        
+        # Get the log file
+        log_file = info.get('log_file')
+        model = info.get('model', 'qwen2.5-coder:0.5b')
+        analyze = info.get('analyze', True)
+        
+        if not log_file or not os.path.exists(log_file):
+            print(f"{Colors.RED}Error: Log file no longer exists.{Colors.END}")
+            return False
+        
+        print(f"{Colors.GREEN}Connecting to legacy monitor for {log_file}...{Colors.END}")
+        from .monitor import monitor_log
+        
+        # Start monitoring in foreground mode (will show output)
+        monitor_log(log_file, background=False, analyze=analyze, model=model,
+                   show_analysis_only=show_analysis_only)
+        return True
+    
+    print(f"{Colors.RED}Error: No monitor found with ID {session_id}.{Colors.END}")
+    return False
+
+def open_session_monitor(session_id=None, show_analysis_only=False):
+    """
+    Open and connect to a specific log monitor session.
+    
+    Args:
+        session_id: Optional session ID to connect to. If not provided, will prompt user to select
+        show_analysis_only: If True, only show analysis without raw log lines
+        
+    Returns:
+        True if successfully connected to a monitor, False otherwise
+    """
+    if not session_id:
+        # Display active monitors first
+        has_monitors = list_active_log_monitors(non_interactive=True)
+        
+        if not has_monitors:
+            print(f"{Colors.YELLOW}No active monitors found to connect to.{Colors.END}")
+            return False
+        
+        # Ask the user to select a monitor
+        try:
+            session_num = int(input(f"{Colors.GREEN}Enter monitor number to connect to (or 0 to cancel): {Colors.END}"))
+            if session_num <= 0:
+                print(f"{Colors.YELLOW}Operation cancelled.{Colors.END}")
+                return False
+                
+            # Get the mapping of indices to session IDs
+            log_monitors = get_active_log_monitors()
+            legacy_monitors = load_monitors()
+            
+            index_to_id = {}
+            
+            # Map session-based monitors
+            for i, sid in enumerate(log_monitors.keys(), 1):
+                index_to_id[i] = sid
+                
+            # Map legacy monitors
+            offset = len(log_monitors)
+            for i, mid in enumerate(legacy_monitors.keys(), offset + 1):
+                index_to_id[i] = mid
+                
+            if session_num not in index_to_id:
+                print(f"{Colors.RED}Invalid monitor number.{Colors.END}")
+                return False
+                
+            session_id = index_to_id[session_num]
+        except ValueError:
+            print(f"{Colors.RED}Invalid input. Please enter a number.{Colors.END}")
+            return False
+        except KeyboardInterrupt:
+            print("\nOperation cancelled.")
+            return False
+    
+    # Connect to the selected monitor
+    return view_monitor(session_id, show_analysis_only) 

--- a/qcmd_cli/log_analysis/monitor.py
+++ b/qcmd_cli/log_analysis/monitor.py
@@ -52,9 +52,17 @@ def load_monitors():
 def cleanup_stale_monitors():
     """
     Clean up monitors that are no longer active.
+    Also ends associated sessions for stale monitors.
+    
+    Returns:
+        Dict of monitors that are still active
     """
+    # Import here to avoid circular imports
+    from ..utils.session import end_session
+    
     monitors = load_monitors()
     updated = {}
+    stale_session_ids = []
     
     for monitor_id, info in monitors.items():
         pid = info.get("pid")
@@ -62,18 +70,45 @@ def cleanup_stale_monitors():
             continue
             
         # Check if process is still running
-        try:
-            os.kill(int(pid), 0)  # Signal 0 doesn't kill the process, just checks if it exists
+        if is_process_running(pid):
             # Process exists, keep the monitor
             updated[monitor_id] = info
-        except (OSError, ValueError):
-            # Process doesn't exist or invalid PID, discard the monitor
-            pass
+        else:
+            # Process doesn't exist, discard the monitor
+            # Also track the session ID for cleanup
+            session_id = info.get("session_id")
+            if session_id:
+                stale_session_ids.append(session_id)
     
+    # End all stale sessions
+    for session_id in stale_session_ids:
+        try:
+            end_session(session_id)
+        except Exception as e:
+            print(f"Error ending session {session_id}: {e}", file=sys.stderr)
+    
+    # Save updated monitors
     save_monitors(updated)
     return updated
 
-def monitor_log(log_file, background=False, analyze=True, model="llama3:latest"):
+# Helper function to check if a process is running
+def is_process_running(pid):
+    """
+    Check if a process with the given PID is running.
+    
+    Args:
+        pid: Process ID to check
+        
+    Returns:
+        True if the process is running, False otherwise
+    """
+    try:
+        os.kill(int(pid), 0)  # Signal 0 doesn't kill the process, just checks if it exists
+        return True
+    except (OSError, ValueError):
+        return False
+
+def monitor_log(log_file, background=False, analyze=True, model="qwen2.5-coder:0.5b", show_analysis_only=False):
     """
     Start monitoring a log file for changes.
     
@@ -82,6 +117,7 @@ def monitor_log(log_file, background=False, analyze=True, model="llama3:latest")
         background: Whether to run in background mode
         analyze: Whether to analyze the log content
         model: Model to use for analysis
+        show_analysis_only: If True, only shows analysis summaries, not raw log lines
     """
     log_file = os.path.abspath(log_file)
     
@@ -92,6 +128,9 @@ def monitor_log(log_file, background=False, analyze=True, model="llama3:latest")
     if not os.path.isfile(log_file):
         print(f"{Colors.RED}Error: '{log_file}' is not a file.{Colors.END}")
         return
+    
+    # Import session management functions
+    from ..utils.session import create_log_monitor_session, end_session, update_session_activity
     
     # If running in background mode, fork a new process
     if background:
@@ -104,6 +143,9 @@ def monitor_log(log_file, background=False, analyze=True, model="llama3:latest")
                 print(f"{Colors.GREEN}Started monitoring {log_file} in background (PID: {pid}).{Colors.END}")
                 print(f"{Colors.YELLOW}Analysis results will be displayed in the terminal where the monitor is running.{Colors.END}")
                 
+                # Create a session for this monitor
+                session_id = create_log_monitor_session(log_file, model, analyze)
+                
                 # Save the monitor information
                 monitors = load_monitors()
                 
@@ -115,7 +157,8 @@ def monitor_log(log_file, background=False, analyze=True, model="llama3:latest")
                     "pid": pid,
                     "started_at": time.strftime("%Y-%m-%d %H:%M:%S"),
                     "model": model,
-                    "analyze": analyze
+                    "analyze": analyze,
+                    "session_id": session_id  # Store the session ID
                 }
                 
                 save_monitors(monitors)
@@ -134,18 +177,28 @@ def monitor_log(log_file, background=False, analyze=True, model="llama3:latest")
         except OSError as e:
             print(f"{Colors.RED}Error: Could not create background process: {e}{Colors.END}")
             return
+    
+    # Create a session for the foreground monitor as well
+    session_id = create_log_monitor_session(log_file, model, analyze)
         
     def cleanup():
-        # Remove from active monitors
+        # Remove from active monitors and end the session
         try:
             if background:
                 monitors = load_monitors()
                 # Find and remove the monitor for this process
                 for monitor_id, info in list(monitors.items()):
                     if info.get("pid") == os.getpid():
+                        # End the session
+                        if "session_id" in info:
+                            end_session(info["session_id"])
+                        # Remove the monitor
                         del monitors[monitor_id]
                         save_monitors(monitors)
                         break
+            else:
+                # End the session for foreground monitors too
+                end_session(session_id)
         except:
             # Ignore errors during cleanup
             pass
@@ -156,10 +209,35 @@ def monitor_log(log_file, background=False, analyze=True, model="llama3:latest")
     
     try:
         print(f"{Colors.GREEN}Monitoring {Colors.BOLD}{log_file}{Colors.END}")
-        print(f"{Colors.GREEN}Press Ctrl+C to stop.{Colors.END}")
+        
+        # Display mode information
+        if analyze:
+            if show_analysis_only:
+                print(f"{Colors.YELLOW}Mode: Analysis only (log lines hidden){Colors.END}")
+            else:
+                print(f"{Colors.YELLOW}Mode: Full monitoring with analysis{Colors.END}")
+        else:
+            print(f"{Colors.YELLOW}Mode: Watch only (no analysis){Colors.END}")
+        
+        print(f"{Colors.GREEN}Press Ctrl+C to stop or 'm' to toggle display mode.{Colors.END}")
+        
+        # Set up nonblocking input for mode switching
+        import select
+        import termios
+        import tty
+        
+        # Save original terminal settings
+        old_settings = termios.tcgetattr(sys.stdin)
         
         # Get the initial file size
         file_size = os.path.getsize(log_file)
+        
+        # Set up a time for session activity updates
+        last_activity_update = time.time()
+        activity_update_interval = 60  # Update activity every 60 seconds
+        
+        # Track current display mode
+        current_show_analysis_only = show_analysis_only
         
         # Do initial analysis if requested
         if analyze:
@@ -167,12 +245,28 @@ def monitor_log(log_file, background=False, analyze=True, model="llama3:latest")
                 content = f.read()
                 if content.strip():
                     print(f"{Colors.CYAN}Analyzing existing log content...{Colors.END}")
+                    if not current_show_analysis_only:
+                        print(f"\n{Colors.YELLOW}--- Existing Log Content ---{Colors.END}")
+                        print(content)
+                        print(f"{Colors.YELLOW}--- End of Existing Content ---{Colors.END}\n")
+                    
+                    print(f"{Colors.CYAN}--- Analysis Results ---{Colors.END}")
                     analyze_log_content(content, log_file, model)
+                    print(f"{Colors.CYAN}--- End of Analysis ---{Colors.END}\n")
         
         # Main monitoring loop
         print(f"\n{Colors.YELLOW}Waiting for new log entries...{Colors.END}")
         
+        # Set terminal to raw mode for detecting keypress
+        tty.setraw(sys.stdin.fileno())
+        
         while True:
+            # Update session activity periodically
+            current_time = time.time()
+            if current_time - last_activity_update > activity_update_interval:
+                update_session_activity(session_id)
+                last_activity_update = current_time
+                
             # Check if the file has been updated
             current_size = os.path.getsize(log_file)
             
@@ -185,23 +279,57 @@ def monitor_log(log_file, background=False, analyze=True, model="llama3:latest")
                     # Read new content
                     new_content = f.read()
                     
+                    # Get current time for timestamp
+                    timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+                    
                     # Print the new content
                     if not analyze:
-                        print(f"{Colors.CYAN}New log entries:{Colors.END}")
+                        print(f"\n{Colors.CYAN}[{timestamp}] New log entries:{Colors.END}")
                         print(new_content)
                     else:
-                        print(f"{Colors.CYAN}Analyzing new log entries...{Colors.END}")
+                        if not current_show_analysis_only:
+                            print(f"\n{Colors.CYAN}[{timestamp}] New log entries:{Colors.END}")
+                            print(f"{Colors.YELLOW}--- Begin New Log Content ---{Colors.END}")
+                            print(new_content)
+                            print(f"{Colors.YELLOW}--- End New Log Content ---{Colors.END}")
+                        
+                        print(f"\n{Colors.GREEN}[{timestamp}] Log Analysis:{Colors.END}")
+                        print(f"{Colors.CYAN}--- Begin Analysis Results ---{Colors.END}")
                         analyze_log_content(new_content, log_file, model)
+                        print(f"{Colors.CYAN}--- End Analysis Results ---{Colors.END}")
                         
                 # Update file size
                 file_size = current_size
+                
+                # Update session activity after processing new content
+                update_session_activity(session_id)
+                last_activity_update = time.time()
+            
+            # Check for keypress to toggle modes
+            if select.select([sys.stdin], [], [], 0.1)[0]:
+                key = sys.stdin.read(1)
+                if key.lower() == 'm':
+                    current_show_analysis_only = not current_show_analysis_only
+                    # Restore terminal settings temporarily to print mode change
+                    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
+                    if current_show_analysis_only:
+                        print(f"\n{Colors.GREEN}Switched to analysis-only mode (log lines hidden){Colors.END}")
+                    else:
+                        print(f"\n{Colors.GREEN}Switched to full mode (showing both log lines and analysis){Colors.END}")
+                    # Return to raw mode
+                    tty.setraw(sys.stdin.fileno())
             
             # Sleep for a bit to avoid high CPU usage
-            time.sleep(1)
+            time.sleep(0.5)
             
     except KeyboardInterrupt:
         print(f"\n{Colors.YELLOW}Monitoring stopped.{Colors.END}")
     except Exception as e:
         print(f"{Colors.RED}Error monitoring log file: {e}{Colors.END}")
     finally:
+        # Restore terminal settings
+        try:
+            termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
+        except:
+            pass
         cleanup() 

--- a/qcmd_cli/utils/session.py
+++ b/qcmd_cli/utils/session.py
@@ -193,4 +193,42 @@ def is_process_running(pid):
             # Unknown OS
             return False
     except (ValueError, TypeError):
-        return False 
+        return False
+
+def create_log_monitor_session(log_file: str, model: str, analyze: bool = True) -> str:
+    """
+    Create a new session for log monitoring.
+    
+    Args:
+        log_file: Path to the log file being monitored
+        model: Model used for analysis
+        analyze: Whether to analyze the log content
+        
+    Returns:
+        Session ID as a string
+    """
+    session_info = {
+        'type': 'log_monitor',
+        'log_file': log_file,
+        'model': model,
+        'analyze': analyze,
+        'start_time': time.strftime("%Y-%m-%d %H:%M:%S")
+    }
+    
+    return create_session(session_info)
+
+def get_active_log_monitors() -> Dict[str, Dict[str, Any]]:
+    """
+    Get all active log monitoring sessions.
+    
+    Returns:
+        Dictionary of session IDs to session information
+    """
+    sessions = load_sessions()
+    log_monitors = {}
+    
+    for session_id, session_info in sessions.items():
+        if session_info.get('type') == 'log_monitor' and is_process_running(session_info.get('pid', 0)):
+            log_monitors[session_id] = session_info
+            
+    return log_monitors 

--- a/tests/unit/test_log_analysis_integration.py
+++ b/tests/unit/test_log_analysis_integration.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Tests for integration between log analysis components.
+"""
+
+import unittest
+import os
+import sys
+import json
+import tempfile
+import time
+from unittest.mock import patch, MagicMock, call
+
+# Add parent directory to path so we can import modules
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+# Import functions to test
+from qcmd_cli.log_analysis.log_files import (
+    handle_log_analysis, handle_log_selection, 
+    list_active_log_monitors, stop_log_monitor
+)
+from qcmd_cli.log_analysis.monitor import monitor_log
+from qcmd_cli.log_analysis.analyzer import analyze_log_file
+from qcmd_cli.utils.session import (
+    create_log_monitor_session, get_active_log_monitors, 
+    load_sessions, end_session
+)
+
+
+class TestLogAnalysisIntegration(unittest.TestCase):
+    """Test the integration between log analysis components."""
+    
+    def setUp(self):
+        """Set up a temporary environment for testing."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.sessions_file = os.path.join(self.temp_dir.name, "sessions.json")
+        self.monitors_file = os.path.join(self.temp_dir.name, "active_monitors.json")
+        
+        # Patch sessions file path
+        self.sessions_patch = patch('qcmd_cli.utils.session.SESSIONS_FILE', self.sessions_file)
+        self.sessions_patch.start()
+        
+        # Patch monitors file path
+        self.monitors_patch = patch('qcmd_cli.log_analysis.monitor.MONITORS_FILE', self.monitors_file)
+        self.monitors_patch.start()
+        
+        # Create test log file
+        self.test_log_file = os.path.join(self.temp_dir.name, "test.log")
+        with open(self.test_log_file, 'w') as f:
+            f.write("This is a test log file\n")
+        
+    def tearDown(self):
+        """Clean up temporary files and patches."""
+        self.sessions_patch.stop()
+        self.monitors_patch.stop()
+        self.temp_dir.cleanup()
+    
+    def test_handle_log_selection_with_analyze_once(self):
+        """Test handle_log_selection with analyze once option."""
+        with patch('builtins.input', return_value='a'), \
+             patch('qcmd_cli.log_analysis.analyzer.analyze_log_file') as mock_analyze:
+            
+            handle_log_selection(self.test_log_file, "test-model")
+            
+            # Verify analyze_log_file was called correctly
+            mock_analyze.assert_called_once_with(self.test_log_file, "test-model")
+    
+    def test_handle_log_selection_with_monitor(self):
+        """Test handle_log_selection with monitor option."""
+        with patch('builtins.input', return_value='m'), \
+             patch('qcmd_cli.log_analysis.monitor.monitor_log') as mock_monitor:
+            
+            handle_log_selection(self.test_log_file, "test-model")
+            
+            # Verify monitor_log was called correctly
+            mock_monitor.assert_called_once_with(
+                self.test_log_file, 
+                background=True, 
+                analyze=True, 
+                model="test-model"
+            )
+    
+    def test_handle_log_selection_with_watch(self):
+        """Test handle_log_selection with watch option."""
+        with patch('builtins.input', return_value='w'), \
+             patch('qcmd_cli.log_analysis.monitor.monitor_log') as mock_monitor:
+            
+            handle_log_selection(self.test_log_file, "test-model")
+            
+            # Verify monitor_log was called correctly
+            mock_monitor.assert_called_once_with(
+                self.test_log_file, 
+                background=True, 
+                analyze=False, 
+                model="test-model"
+            )
+    
+    def test_handle_log_analysis_with_specific_file(self):
+        """Test handle_log_analysis with a specific file path."""
+        with patch('builtins.input', return_value='1'), \
+             patch('qcmd_cli.log_analysis.analyzer.analyze_log_file') as mock_analyze, \
+             patch('qcmd_cli.log_analysis.log_files.list_active_log_monitors'):
+            
+            handle_log_analysis("test-model", self.test_log_file)
+            
+            # Verify analyze_log_file was called with the specific file
+            mock_analyze.assert_called_once()
+    
+    def test_handle_log_analysis_with_no_monitors(self):
+        """Test handle_log_analysis when no monitors are active."""
+        # Create empty monitoring state
+        with open(self.sessions_file, 'w') as f:
+            json.dump({}, f)
+        
+        # Mock user inputs and function calls
+        with patch('builtins.input', side_effect=['c', 'q']), \
+             patch('qcmd_cli.log_analysis.log_files.find_log_files', return_value=[self.test_log_file]), \
+             patch('qcmd_cli.log_analysis.log_files.display_log_selection', return_value=None) as mock_display:
+            
+            handle_log_analysis("test-model")
+            
+            # Verify display_log_selection was called
+            mock_display.assert_called_once()
+    
+    def test_handle_log_analysis_stop_monitor(self):
+        """Test handle_log_analysis when stopping a monitor."""
+        # Create test session data
+        session_id = "test-session-1"
+        test_sessions = {
+            session_id: {
+                "type": "log_monitor",
+                "log_file": self.test_log_file,
+                "pid": os.getpid(),
+                "model": "test-model",
+                "analyze": True
+            }
+        }
+        
+        with open(self.sessions_file, 'w') as f:
+            json.dump(test_sessions, f)
+        
+        # Mock inputs and function calls
+        with patch('builtins.input', side_effect=['s', '1', 'n']), \
+             patch('qcmd_cli.utils.session.is_process_running', return_value=True), \
+             patch('qcmd_cli.log_analysis.log_files.stop_log_monitor') as mock_stop:
+            
+            handle_log_analysis("test-model")
+            
+            # Verify stop_log_monitor was called with the session ID
+            mock_stop.assert_called_once_with(session_id)
+    
+    def test_stop_monitor_with_invalid_session(self):
+        """Test stopping a monitor with an invalid session ID."""
+        # Empty sessions file
+        with open(self.sessions_file, 'w') as f:
+            json.dump({}, f)
+            
+        # Try to stop a non-existent session
+        result = stop_log_monitor("non-existent-session")
+        
+        # Should return False
+        self.assertFalse(result)
+    
+    def test_handle_log_analysis_journalctl(self):
+        """Test handle_log_analysis with a journalctl service."""
+        journalctl_log = "journalctl:test.service"
+        
+        # Mock inputs and functions
+        with patch('builtins.input', side_effect=['c', journalctl_log, 'a']), \
+             patch('qcmd_cli.log_analysis.log_files.find_log_files', return_value=[journalctl_log]), \
+             patch('qcmd_cli.log_analysis.log_files.display_log_selection', return_value=journalctl_log), \
+             patch('tempfile.NamedTemporaryFile'), \
+             patch('subprocess.check_output', return_value="Test log content"), \
+             patch('qcmd_cli.log_analysis.analyzer.analyze_log_file') as mock_analyze:
+            
+            handle_log_analysis("test-model")
+            
+            # Verify analyze_log_file was called (specific arguments are hard to test due to temp file)
+            mock_analyze.assert_called_once()
+    
+    def test_active_log_monitors_integration(self):
+        """Test the integration between get_active_log_monitors and list_active_log_monitors."""
+        # Create test session data
+        test_sessions = {
+            "test-session-1": {
+                "type": "log_monitor",
+                "log_file": self.test_log_file,
+                "pid": os.getpid(),
+                "model": "test-model",
+                "analyze": True,
+                "start_time": time.strftime("%Y-%m-%d %H:%M:%S")
+            }
+        }
+        
+        with open(self.sessions_file, 'w') as f:
+            json.dump(test_sessions, f)
+        
+        # Mock process check and capture print output
+        with patch('qcmd_cli.utils.session.is_process_running', return_value=True), \
+             patch('builtins.print') as mock_print:
+            
+            list_active_log_monitors()
+            
+            # Verify print was called with the expected text
+            # We can't easily test the exact output, but we can check if a key phrase was printed
+            found = False
+            for call_args in mock_print.call_args_list:
+                args = call_args[0]
+                if args and isinstance(args[0], str) and "Active Log Monitors" in args[0]:
+                    found = True
+                    break
+            
+            self.assertTrue(found, "Active Log Monitors heading not found in output")
+
+
+if __name__ == '__main__':
+    unittest.main() 

--- a/tests/unit/test_log_monitor_session.py
+++ b/tests/unit/test_log_monitor_session.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+Tests for log monitoring session functionality.
+"""
+
+import unittest
+import os
+import sys
+import json
+import tempfile
+import time
+import signal
+from unittest.mock import patch, MagicMock, call
+
+# Add parent directory to path so we can import modules
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+# Import functions to test
+from qcmd_cli.utils.session import (
+    create_log_monitor_session, get_active_log_monitors, 
+    load_sessions, save_session, end_session, update_session_activity
+)
+from qcmd_cli.log_analysis.log_files import list_active_log_monitors, stop_log_monitor, handle_log_analysis
+from qcmd_cli.log_analysis.monitor import monitor_log, save_monitors, load_monitors, cleanup_stale_monitors
+
+
+class TestLogMonitorSession(unittest.TestCase):
+    """Test the log monitoring session functionality."""
+    
+    def setUp(self):
+        """Set up a temporary sessions file for testing."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.sessions_file = os.path.join(self.temp_dir.name, "sessions.json")
+        self.monitors_file = os.path.join(self.temp_dir.name, "active_monitors.json")
+        
+        # Patch sessions file path
+        self.sessions_patch = patch('qcmd_cli.utils.session.SESSIONS_FILE', self.sessions_file)
+        self.sessions_patch.start()
+        
+        # Patch monitors file path
+        self.monitors_patch = patch('qcmd_cli.log_analysis.monitor.MONITORS_FILE', self.monitors_file)
+        self.monitors_patch.start()
+        
+        # Create test log file
+        self.test_log_file = os.path.join(self.temp_dir.name, "test.log")
+        with open(self.test_log_file, 'w') as f:
+            f.write("This is a test log file\n")
+        
+    def tearDown(self):
+        """Clean up temporary files and patches."""
+        self.sessions_patch.stop()
+        self.monitors_patch.stop()
+        self.temp_dir.cleanup()
+    
+    def test_create_log_monitor_session(self):
+        """Test creating a log monitor session."""
+        log_file = self.test_log_file
+        model = "qwen2.5-coder:0.5b"
+        
+        with patch('qcmd_cli.utils.session.os.getpid', return_value=12345):
+            session_id = create_log_monitor_session(log_file, model)
+            
+            # Verify session was created
+            with open(self.sessions_file, 'r') as f:
+                sessions = json.load(f)
+                
+            self.assertIn(session_id, sessions)
+            session = sessions[session_id]
+            self.assertEqual(session['type'], 'log_monitor')
+            self.assertEqual(session['log_file'], log_file)
+            self.assertEqual(session['model'], model)
+            self.assertEqual(session['pid'], 12345)
+            self.assertTrue(session['analyze'])
+    
+    def test_get_active_log_monitors(self):
+        """Test getting active log monitor sessions."""
+        # Create a mock session file with a log monitor session
+        test_sessions = {
+            "test-session-1": {
+                "type": "log_monitor",
+                "log_file": "/var/log/test1.log",
+                "pid": os.getpid(),  # Current process should be considered running
+                "model": "qwen2.5-coder:0.5b",
+                "analyze": True
+            },
+            "test-session-2": {
+                "type": "log_monitor",
+                "log_file": "/var/log/test2.log",
+                "pid": 99999,  # This process likely doesn't exist
+                "model": "qwen2.5-coder:0.5b",
+                "analyze": False
+            },
+            "test-session-3": {
+                "type": "interactive_shell",  # Not a log monitor
+                "pid": os.getpid()
+            }
+        }
+        
+        with open(self.sessions_file, 'w') as f:
+            json.dump(test_sessions, f)
+        
+        # Mock the is_process_running function to only return True for the current process
+        with patch('qcmd_cli.utils.session.is_process_running', 
+                   side_effect=lambda pid: pid == os.getpid()):
+            
+            active_monitors = get_active_log_monitors()
+            
+            # Should only return the active log monitor session
+            self.assertEqual(len(active_monitors), 1)
+            self.assertIn("test-session-1", active_monitors)
+            self.assertNotIn("test-session-2", active_monitors)  # Inactive process
+            self.assertNotIn("test-session-3", active_monitors)  # Not a log monitor
+    
+    def test_stop_log_monitor(self):
+        """Test stopping a log monitor."""
+        # Create a mock session file with a log monitor session
+        test_pid = os.getpid()  # Use current process for testing
+        test_sessions = {
+            "test-session-1": {
+                "type": "log_monitor",
+                "log_file": "/var/log/test1.log",
+                "pid": test_pid,
+                "model": "qwen2.5-coder:0.5b"
+            }
+        }
+        
+        with open(self.sessions_file, 'w') as f:
+            json.dump(test_sessions, f)
+        
+        # Mock os.kill to avoid actually killing our test process
+        with patch('os.kill') as mock_kill:
+            # Test stopping the monitor
+            result = stop_log_monitor("test-session-1")
+            
+            # Should return True indicating success
+            self.assertTrue(result)
+            
+            # Should have called kill with our PID
+            mock_kill.assert_called_once_with(test_pid, signal.SIGTERM)
+            
+            # Session should be removed
+            with open(self.sessions_file, 'r') as f:
+                sessions = json.load(f)
+                self.assertNotIn("test-session-1", sessions)
+                
+    def test_integration_monitor_session(self):
+        """Test the integration between monitor and session systems"""
+        # Set up a temporary log file
+        log_file = self.test_log_file
+        log_file.write_text("Sample log content")
+        
+        # Mock the main components
+        mock_save = MagicMock()
+        mock_load = MagicMock(return_value={
+            'active-monitor': {
+                'pid': 9999,
+                'log_file': str(log_file),
+                'started_at': '2022-01-01 00:00:00',
+                'model': 'test-model'
+            }
+        })
+        
+        with patch('qcmd_cli.log_analysis.monitor.save_monitors', mock_save), \
+             patch('qcmd_cli.log_analysis.monitor.load_monitors', mock_load):
+            
+            # Mock session functions
+            mock_save_session = MagicMock()
+            mock_load_sessions = MagicMock(return_value={
+                'test-session-id': {
+                    'created_at': '2022-01-01 00:00:00',
+                    'last_active': '2022-01-01 00:00:00',
+                    'monitor_id': 'active-monitor'
+                }
+            })
+            mock_is_active = MagicMock(return_value=True)
+            
+            with patch('qcmd_cli.utils.session.save_session', mock_save_session), \
+                 patch('qcmd_cli.utils.session.load_sessions', mock_load_sessions), \
+                 patch('qcmd_cli.utils.session.is_session_active', mock_is_active):
+                
+                # Mock process existence check
+                with patch('psutil.pid_exists', lambda pid: True):
+                    
+                    # Create a monitor with a session
+                    result = monitor_log(str(log_file), 'test-model', background=True)
+                    assert result, "Monitor should have been created"
+                    
+                    # When listing active monitors, ensure it uses the non-interactive mode
+                    list_result = list_active_log_monitors(non_interactive=True)
+                    assert list_result, "Should have found active monitors"
+                    
+                    # Verify the session was saved
+                    assert mock_save_session.called, "Session should have been saved"
+                    
+                    # Verify the session info
+                    call_args = mock_save_session.call_args[0]
+                    assert len(call_args) >= 1, "Session save should have been called with session ID"
+                    session_id = call_args[0]
+                    
+                    # Check that the session was created with the monitor ID
+                    mock_save_session.assert_called_with(
+                        session_id,
+                        {
+                            'created_at': mock.ANY,
+                            'last_active': mock.ANY,
+                            'monitor_id': mock.ANY
+                        }
+                    )
+                    
+                    # Test session update
+                    update_session_activity(session_id)
+                    assert mock_save_session.call_count >= 2, "Session should have been updated"
+    
+    def test_cleanup_stale_monitors(self):
+        """Test cleaning up stale monitors."""
+        # Skip the real file operations and focus on the logic
+        active_pid = os.getpid()
+        stale_pid = 99999  # Unlikely to exist
+        
+        # Test data
+        test_monitor_data = {
+            "active-monitor": {
+                "pid": active_pid,
+                "session_id": "active-session-id"
+            },
+            "stale-monitor": {
+                "pid": stale_pid,
+                "session_id": "stale-session-id"
+            }
+        }
+        
+        # Mock load_monitors to return our test data
+        with patch('qcmd_cli.log_analysis.monitor.load_monitors', return_value=test_monitor_data), \
+             patch('qcmd_cli.log_analysis.monitor.save_monitors') as mock_save, \
+             patch('qcmd_cli.log_analysis.monitor.is_process_running', lambda pid: int(pid) == active_pid), \
+             patch('qcmd_cli.utils.session.end_session') as mock_end_session:
+            
+            # Run the cleanup
+            result = cleanup_stale_monitors()
+            
+            # Verify end_session was called with stale session ID
+            mock_end_session.assert_called_once_with("stale-session-id")
+            
+            # Verify save_monitors was called with only the active monitor
+            self.assertEqual(len(mock_save.call_args[0][0]), 1)
+            self.assertIn("active-monitor", mock_save.call_args[0][0])
+            self.assertNotIn("stale-monitor", mock_save.call_args[0][0])
+            
+            # Verify the result includes only the active monitor
+            self.assertEqual(len(result), 1)
+            self.assertIn("active-monitor", result)
+    
+    def test_foreground_monitoring_creates_session(self):
+        """Test that foreground monitoring creates a session."""
+        # Use specific file path to avoid issues with path differences
+        absolute_test_file = os.path.abspath(self.test_log_file)
+        
+        # Mock to avoid actually monitoring
+        with patch('qcmd_cli.utils.session.create_log_monitor_session', return_value="test-session-id") as mock_create_session, \
+             patch('qcmd_cli.log_analysis.monitor.signal.signal'), \
+             patch('qcmd_cli.log_analysis.monitor.os.path.getsize', return_value=0), \
+             patch('qcmd_cli.log_analysis.monitor.time.sleep', side_effect=KeyboardInterrupt):
+            
+            # This should return due to KeyboardInterrupt in the mock
+            monitor_log(absolute_test_file, background=False, analyze=True, model="test-model")
+            
+            # Verify session creation was called with the correct parameters
+            mock_create_session.assert_called_once_with(absolute_test_file, "test-model", True)
+    
+    def test_session_cleanup_on_exit(self):
+        """Test that the session is cleaned up when monitoring ends."""
+        session_id = "test-cleanup-session"
+        absolute_test_file = os.path.abspath(self.test_log_file)
+        
+        # Create a session
+        test_sessions = {
+            session_id: {
+                "type": "log_monitor",
+                "log_file": absolute_test_file,
+                "pid": os.getpid(),
+                "model": "test-model"
+            }
+        }
+        
+        with open(self.sessions_file, 'w') as f:
+            json.dump(test_sessions, f)
+        
+        # Mock necessary functions and cause a KeyboardInterrupt to exit monitoring
+        with patch('qcmd_cli.utils.session.create_log_monitor_session', return_value=session_id), \
+             patch('qcmd_cli.utils.session.end_session') as mock_end_session, \
+             patch('qcmd_cli.log_analysis.monitor.signal.signal'), \
+             patch('qcmd_cli.log_analysis.monitor.os.path.getsize', return_value=0), \
+             patch('qcmd_cli.log_analysis.monitor.time.sleep', side_effect=KeyboardInterrupt), \
+             patch('qcmd_cli.utils.session.is_process_running', return_value=True), \
+             patch('qcmd_cli.log_analysis.monitor.is_process_running', return_value=True):
+            
+            # This should return due to KeyboardInterrupt in the mock
+            monitor_log(absolute_test_file, background=False)
+            
+            # Verify end_session was called with our session ID
+            mock_end_session.assert_called_once_with(session_id)
+
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
This PR adds enhanced log monitor display options:
   
   - Adds ability to toggle between showing full log entries with analysis or just analysis results
   - Improves the formatting of log output with clearer separation between content and analysis
   - Adds timestamps to each new batch of log entries
   - Provides real-time toggle (press 'm' while viewing) to switch display modes
   - Updates CLI arguments to support selecting display mode from command line
   - Enhances the monitor options menu with clearer choices
   
   These changes make it easier for users to focus on either raw log entries or analysis results based on their needs.